### PR TITLE
Feature/cascading tie breaks

### DIFF
--- a/app/lib/medals.json
+++ b/app/lib/medals.json
@@ -36,8 +36,8 @@
  },
  {
    "code": "ITA",
-   "gold": 0,
-   "silver": 2,
+   "gold": 2,
+   "silver": 8,
    "bronze": 6
  },
  {


### PR DESCRIPTION
when selecting by a specific column and a tie exists, we currently pick by a higher medal and pick the rank.
For example: if your ranking by Bronze, and a tie was discovered we  sort the tied countries by gold, and the higher golds come out on top, but what if their exists a tie in golds ? This PR solves that problem, by recursively going down the other medals like silver and if a tie was found their it goes down to bronze. This way the original order stays unsorted only if a tie breaker wasn't resolved down the medal chain.